### PR TITLE
Fix I2C Address Decoding, Fix IRQ priority

### DIFF
--- a/bus.c
+++ b/bus.c
@@ -140,7 +140,7 @@ ISR(TWI0_TWIS_vect) {
                 case Bus_AddressOrRead:
                 {
                     uint8_t addr = TWI0.SDATA;
-                    if (addr & HIMEM_MASK) {
+                    if ((addr & HIMEM_MASK) == HIMEM_MASK) {
                         bus_state.activePage    = CONFIG_PAGE;
                         addr                    = addr & ~HIMEM_MASK;
                     } else {

--- a/configs/attiny402.h
+++ b/configs/attiny402.h
@@ -54,6 +54,9 @@
 //#define CONFIG_HW_EVSYS_USER_SYNC0              DEF_HW_EVSYS_CHANNEL_OFF
 //#define CONFIG_HW_EVSYS_USER_SYNC1              DEF_HW_EVSYS_CHANNEL_OFF
 
+// Prioritize LED IRQ
+#define CONFIG_HW_IRQ_PRIORITY                  USART0_DRE_vect_num
+
 // *****************************************************************************
 // **** KeyPad Hardware Configuration ******************************************
 // *****************************************************************************
@@ -99,8 +102,6 @@
 #error "Bad test case selected"
 #endif
 #endif
-
-
 
 // When CONFIG_LED_IRQ_PERF is set use this port for toggling...
 #if 0

--- a/configs/attiny804.h
+++ b/configs/attiny804.h
@@ -15,8 +15,8 @@
  * | 1   |      | VCC         | 5V                                                    |
  * | 2   | PA4  | LUT0.OUT    | WS2812 Serial Waveform                                |
  * | 3   | PA5  | AIN5        | Analog Keypad                                         |
- * | 4   | PA6  |             | Unused.                                               |
- * | 5   | PA7  |             | Unused.                                               |
+ * | 4   | PA6  |             | Unused / LED_IRQ_PERF                                 |
+ * | 5   | PA7  |             | Unused / KP_IRQ_PERF                                  |
  * | 6   | PB3  |             | Unused.                                               |
  * | 7   | PB2  |             | Unused.                                               |
  * | 8   | PB1  | TWI.SDA     | TWI (I2C) Data Signal                                 |
@@ -64,25 +64,21 @@
 //#define CONFIG_HW_EVSYS_USER_ASYNC10            DEF_HW_EVSYS_CHANNEL_OFF
 //#define CONFIG_HW_EVSYS_USER_SYNC0              DEF_HW_EVSYS_CHANNEL_OFF
 //#define CONFIG_HW_EVSYS_USER_SYNC1              DEF_HW_EVSYS_CHANNEL_OFF
+// Prioritize LED IRQ
+#define CONFIG_HW_IRQ_PRIORITY                  USART0_DRE_vect_num
+
+//#define CONFIG_LED_IRQ_PERF                     DEF_ENABLE
+#define CONFIG_LED_IRQ_PORT                     VPORTA
+#define CONFIG_LED_IRQ_PIN                      6
 
 // *****************************************************************************
 // **** KeyPad Hardware Configuration ******************************************
 // *****************************************************************************
 #define CONFIG_KP_ADC_PIN                       5
 
-// When CONFIG_LED_IRQ_PERF is set use this port for toggling...
-#if 0
-#define CONFIG_LED_IRQ_PERF                     DEF_ENABLE
-#define CONFIG_LED_IRQ_PORT                     VPORTA
-#define CONFIG_LED_IRQ_PIN                      2               // Reuses SCL pin
-#define CONFIG_BUS_ENABLE                       DEF_DISABLE     // Can't use I2C with this configuration
-
-#if defined(CONFIG_LED_IRQ_PERF) && CONFIG_LED_IRQ_PERF
-// Forces test mode when performance mode is selected.
-#define CONFIG_TEST_PATTERN                     DEF_TEST_PATTERN_TYPE_SINGLE_FADE
-//#define CONFIG_TEST_ABORT                       8
-#endif
-#endif
+//#define CONFIG_KP_IRQ_PERF                      DEF_ENABLE
+#define CONFIG_KP_IRQ_PORT                      VPORTA
+#define CONFIG_KP_IRQ_PIN                       7
 
 #endif	/* ATTINY804_H */
 

--- a/device_config.h
+++ b/device_config.h
@@ -158,6 +158,11 @@
 #endif
 #define F_CPU                                   CONFIG_CLOCK
 
+// ==== CONFIG_HW_IRQ_PRIORITY =================================================
+#ifndef CONFIG_HW_IRQ_PRIORITY
+#define CONFIG_HW_IRQ_PRIORITY DEF_DISABLE
+#endif
+
 // ==== CONFIG_SLEEP ===========================================================
 #ifndef CONFIG_SLEEP
 #define CONFIG_SLEEP                            DEF_SLEEP_STANDBY
@@ -266,6 +271,10 @@
 #endif
 
 // *****************************************************************************
+// **** LED Configuration ******************************************************
+// *****************************************************************************
+
+// *****************************************************************************
 // *** Keypad Support **********************************************************
 // *****************************************************************************
 
@@ -289,6 +298,19 @@
  */
 #ifndef CONFIG_KP_HISTORY
 #define CONFIG_KP_HISTORY                       DEF_DISABLE
+#endif
+
+// ==== CONFIG_LED_IRQ_PERF, CONFIG_LED_IRQ_PORT, CONFIG_LED_IRQ_PIN ===========
+#ifndef CONFIG_KP_IRQ_PERF
+#define CONFIG_KP_IRQ_PERF                     DEF_DISABLE
+#endif
+
+#if CONFIG_KP_IRQ_PERF && !defined(CONFIG_KP_IRQ_PORT)
+#error "Must define CONFIG_KP_IRQ_PORT to use CONFIG_KP_IRQ_PERF."
+#endif
+
+#if CONFIG_KO_IRQ_PERF && !defined(CONFIG_KP_IRQ_PIN)
+#error "Must define CONFIG_KP_IRQ_PORT to use CONFIG_KP_IRQ_PIN."
 #endif
 
 // *****************************************************************************

--- a/keypad.c
+++ b/keypad.c
@@ -27,6 +27,9 @@ SysFinit_Subscribe      (keypad_finit,         Signal_nNormal);
 SysLoop_Subscribe       (keypad_worker,        Signal_Normal);
 
 ISR(ADC0_RESRDY_vect) {
+#if CONFIG_KP_IRQ_PERF
+    CONFIG_KP_IRQ_PORT.OUT |= (1<<CONFIG_KP_IRQ_PIN);
+#endif
     uint8_t raw = ADC0.RES;// >> 2;
     keypad_state.raw = raw;
     ADC0.INTFLAGS = ADC_RESRDY_bm | ADC_WCMP_bm;
@@ -63,6 +66,10 @@ ISR(ADC0_RESRDY_vect) {
         ADC0.WINLT = 0;
         ADC0.INTCTRL = ADC_WCMP_bm;
     }
+
+#if CONFIG_KP_IRQ_PERF
+    CONFIG_KP_IRQ_PORT.OUT &= ~(1<<CONFIG_KP_IRQ_PIN);
+#endif
 }
 
 ISR(ADC0_WCOMP_vect) {
@@ -109,6 +116,11 @@ static void keypad_init () {
     keypad_state.cal.vstep              = adc_code(CONFIG_KP_CAL_STEP);         // 270mV
     keypad_state.cal.steadyStateWindow  = adc_code(CONFIG_KP_CAL_STREADY);      // steady state window
     keypad_state.cal.filter             = CONFIG_KP_CAL_FILTER;                 // number of steady steps before acceptance
+    
+#if CONFIG_KP_IRQ_PERF
+    CONFIG_KP_IRQ_PORT.DIR |= (1<<CONFIG_KP_IRQ_PIN);
+    CONFIG_KP_IRQ_PORT.OUT &= ~(1<<CONFIG_KP_IRQ_PIN);
+#endif
 }
 
 static void keypad_finit () {

--- a/scripts/driver.py
+++ b/scripts/driver.py
@@ -193,7 +193,7 @@ class LedDevice:
         for chunk in [buf[i:i + LedDevice.CHUNK_SIZE] for i in range(0, len(buf), LedDevice.CHUNK_SIZE)]:
             rc, data = self._intf.raw.bulk_trans(len(chunk),chunk)
             if rc != 1 or any(map(lambda x: x == 1, data)):
-                raise BusError("Failed to write buffer.")
+                raise BusError(f"Failed to write buffer. (Size: {len(buf)}; Chunk Size: {len(chunk)})")
         self._intf.raw.send_stop_bit()
 
     def read(self, index, size):

--- a/scripts/ledtest.py
+++ b/scripts/ledtest.py
@@ -22,18 +22,19 @@ def run_test(device):
     Log.i(None, f"Led info: {Util.toHex(ledInfo)}")
 
     device.setTxCommand(8)
-    maxColor = 128
+    maxColor = 16
+    stepSize = 1
     index = 0
     while True:
         if (index & (0x2|0x4|0x8)) == 0:
             index |= 0x2
-        for color in range(0,maxColor,4):
+        for color in range(0,maxColor,stepSize):
             color = maxColor - 1 - color if index & 1 else color
 
             r = color if index & 0x2 else 0
             g = color if index & 0x4 else 0
             b = color if index & 0x8 else 0
-            device.write(3, bytes((g,r,b))*4)
+            device.write(3, bytes((g,r,b))*32)
         index += 1
 
 


### PR DESCRIPTION
- Unintentionally mapped 0x10 - 0xFF to special registers. This ensures only
0xF0 to 0xFF have the special mapping.
- IRQ priorities are now configurable.
- Odds and ends.